### PR TITLE
fixed docs nav bug; docs now pulls from repo's readme.md

### DIFF
--- a/docs-environment.yml
+++ b/docs-environment.yml
@@ -27,6 +27,7 @@ dependencies:
     - babel==2.7.0
     - chardet==3.0.4
     - click==7.0
+    - commonmark==0.9.1
     - docutils==0.15.2
     - flask==1.1.1
     - gast==0.3.2
@@ -39,8 +40,10 @@ dependencies:
     - joblib==0.14.0
     - keras-applications==1.0.8
     - keras-preprocessing==1.1.0
+    - m2r==0.2.1
     - markdown==3.1.1
     - markupsafe==1.1.1
+    - mistune==0.8.4
     - mock==3.0.5
     - numpy==1.17.2
     - packaging==19.2
@@ -72,4 +75,3 @@ dependencies:
     - urllib3==1.25.7
     - werkzeug==0.16.0
 prefix: /data/anaconda/envs/hotdoc-docs
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,8 @@ author = 'AI Singapore'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    #'recommonmark',
+    'm2r', # for importing markdown inside rst. gives '.. mdinclude::' directive
     'sphinx_rtd_theme'
 ]
 
@@ -54,6 +56,13 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# add support for markdown files
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
+}
+
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -61,6 +70,23 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+    'canonical_url': '',
+    'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
+    'logo_only': False,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': False,
+    # 'vcs_pageview_mode': 'raw', # throws error 'unsupported theme option'?
+    # 'style_nav_header_background': 'white',
+    # Toc options
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': True
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,15 +6,15 @@
 Welcome to HotDocs NLP -- Golden Retriever's documentation!
 ===========================================================
 
+Golden Retriever is an information retrieval engine that
+allows you to search unstructured information with
+natural-language queries. Load a
+text document into the engine, ask it a question,
+and get a ranked list of answers.
+
 ..  toctree::
     :maxdepth: 2
-    :caption: Contents:
 
     api/modules
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+..  mdinclude:: ../../README.md


### PR DESCRIPTION
- fixed a bug in my implementation of theme's navbar
- docs now pulls from the repository's readme and publishes as docs front page
- updated docs-environment.yml to support above changes